### PR TITLE
Properly set quic tls variable to openssl on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,12 @@ option(MSH3_TOOL "Build tool" OFF)
 
 # use, i.e. don't skip the full RPATH for the build tree
 set(CMAKE_SKIP_BUILD_RPATH FALSE)
- 
+
 # when building, don't use the install RPATH already
 # (but later on when installing)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
- 
+
 # add the automatically determined parts of the RPATH
 # which point to directories outside the build tree to the install RPATH
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
@@ -29,7 +29,7 @@ option(LSQPACK_BIN "Build binaries" OFF)
 add_subdirectory(ls-qpack)
 
 # Configure and build msquic dependency.
-set(QUIC_TLS "openssl")
+set(QUIC_TLS "openssl" CACHE STRING "TLS Library to use")
 set(QUIC_ENABLE_LOGGING ON CACHE BOOL "Enable MsQuic logging")
 set(CMAKE_BUILD_TYPE "Release")
 add_subdirectory(msquic)


### PR DESCRIPTION
The string wasn't cached, so it was being overwritten