### PR TITLE
Fix Path Arg

### DIFF
--- a/tool/msh3_app.cpp
+++ b/tool/msh3_app.cpp
@@ -79,7 +79,7 @@ void ParseArgs(int argc, char **argv) {
         } else if (!strcmp(argv[i], "--path") || !strcmp(argv[i], "-p")) {
             if (++i >= argc) { printf("Missing path value(s)\n"); exit(-1); }
 
-            char* Path = (char*)argv[1];
+            char* Path = (char*)argv[i];
             do {
                 char* End = strchr(Path, ',');
                 if (End) *End = 0;


### PR DESCRIPTION
Fix #48. The code was incorrectly using `1` instead of `i` for its index in the `argv` array.