### PR TITLE
Fix Uninitialized Headers Struct

### DIFF
--- a/lib/msh3.hpp
+++ b/lib/msh3.hpp
@@ -52,6 +52,7 @@ enum H3SettingsType {
 // Contiguous buffer for (non-null-terminated) header name and value strings.
 struct H3HeadingPair : public lsxpack_header_t {
     char Buffer[512] = {0};
+    H3HeadingPair() { memset(this, sizeof(lsxpack_header_t), 0); }
     bool Set(const MSH3_HEADER* Header) {
         if (Header->NameLength + Header->ValueLength > sizeof(Buffer)) return false;
         buf = Buffer;

--- a/lib/msh3.hpp
+++ b/lib/msh3.hpp
@@ -52,7 +52,7 @@ enum H3SettingsType {
 // Contiguous buffer for (non-null-terminated) header name and value strings.
 struct H3HeadingPair : public lsxpack_header_t {
     char Buffer[512] = {0};
-    H3HeadingPair() { memset(this, sizeof(lsxpack_header_t), 0); }
+    H3HeadingPair() { memset(this, 0, sizeof(lsxpack_header_t)); }
     bool Set(const MSH3_HEADER* Header) {
         if (Header->NameLength + Header->ValueLength > sizeof(Buffer)) return false;
         buf = Buffer;


### PR DESCRIPTION
Fixes:
```
==1929954== Conditional jump or move depends on uninitialised value(s)
==1929954==    at 0x485AEC3: lsqpack_enc_encode (lsqpack.c:1630)
==1929954==    by 0x485687F: MsH3UniDirStream::EncodeHeaders(MsH3BiDirStream*, MSH3_HEADER const*, unsigned long) (in /home/daniel/build-msh3/lib/libmsh3.so)
==1929954==    by 0x4856D27: MsH3BiDirStream::MsH3BiDirStream(MsH3Connection*, MSH3_REQUEST_IF const*, void*, MSH3_HEADER const*, unsigned long, QUIC_STREAM_OPEN_FLAGS) (in /home/daniel/build-msh3/lib/libmsh3.so)
==1929954==    by 0x4856ED7: MsH3Connection::SendRequest(MSH3_REQUEST_IF const*, void*, MSH3_HEADER const*, unsigned long) (in /home/daniel/build-msh3/lib/libmsh3.so)
==1929954==    by 0x183764: msh3_stream_send (msh3.c:408)
==1929954==    by 0x15C310: Curl_write (sendf.c:318)
==1929954==    by 0x1A3E2F: Curl_buffer_send (http.c:1339)
==1929954==    by 0x1A6A8B: Curl_http_bodysend (http.c:2701)
==1929954==    by 0x1A81BA: Curl_http (http.c:3271)
==1929954==    by 0x183065: msh3_do_it (msh3.c:211)
==1929954==    by 0x1543E6: multi_do (multi.c:1563)
==1929954==    by 0x1555AE: multi_runsingle (multi.c:2112)
```