### PR TITLE
Support Full Server Address

### DIFF
--- a/lib/msh3.cpp
+++ b/lib/msh3.cpp
@@ -362,9 +362,9 @@ MsH3Connection::MsH3Connection(
             QUIC_CREDENTIAL_FLAG_CLIENT;
     MsQuicConfiguration Config(Registration, "h3", Settings, Flags);
     if (QUIC_FAILED(InitStatus = Config.GetInitStatus())) return;
-    if (!QuicAddrIsWildCard((QUIC_ADDR*)ServerAddress) &&
-        QUIC_FAILED(InitStatus = SetRemoteAddr(*(QuicAddr*)ServerAddress))) return;
-    if (QUIC_FAILED(InitStatus = Start(Config, HostName, QuicAddrGetPort((QUIC_ADDR*)ServerAddress)))) return;
+    auto QuicAddress = (const QUIC_ADDR*)ServerAddress;
+    if (!QuicAddrIsWildCard(QuicAddress) && QUIC_FAILED(InitStatus = SetRemoteAddr(*(QuicAddr*)ServerAddress))) return;
+    if (QUIC_FAILED(InitStatus = Start(Config, QuicAddrGetFamily(QuicAddress), HostName, QuicAddrGetPort(QuicAddress)))) return;
 }
 
 #ifdef MSH3_SERVER_SUPPORT

--- a/lib/msh3.cpp
+++ b/lib/msh3.cpp
@@ -76,12 +76,12 @@ MsH3ConnectionOpen(
     const MSH3_CONNECTION_IF* Interface,
     void* IfContext,
     const char* ServerName,
-    uint16_t Port,
+    const MSH3_ADDR* ServerAddress,
     bool Unsecure
     )
 {
     auto Reg = (MsQuicRegistration*)Handle;
-    auto H3 = new(std::nothrow) MsH3Connection(*Reg, Interface, IfContext, ServerName, Port, Unsecure);
+    auto H3 = new(std::nothrow) MsH3Connection(*Reg, Interface, IfContext, ServerName, ServerAddress, Unsecure);
     if (!H3 || QUIC_FAILED(H3->GetInitStatus())) {
         delete H3;
         return nullptr;
@@ -332,7 +332,7 @@ MsH3Connection::MsH3Connection(
         const MSH3_CONNECTION_IF* Interface,
         void* IfContext,
         const char* ServerName,
-        uint16_t Port,
+        const MSH3_ADDR* ServerAddress,
         bool Unsecure
     ) : MsQuicConnection(Registration, CleanUpManual, s_MsQuicCallback, this),
         Callbacks(*Interface), Context(IfContext)
@@ -362,8 +362,9 @@ MsH3Connection::MsH3Connection(
             QUIC_CREDENTIAL_FLAG_CLIENT;
     MsQuicConfiguration Config(Registration, "h3", Settings, Flags);
     if (QUIC_FAILED(InitStatus = Config.GetInitStatus())) return;
-    //if (ServerIp && InitStatus = QUIC_FAILED(H3->SetRemoteAddr(ServerAddress))) return;
-    if (QUIC_FAILED(InitStatus = Start(Config, HostName, Port))) return;
+    if (!QuicAddrIsWildCard((QUIC_ADDR*)ServerAddress) &&
+        QUIC_FAILED(InitStatus = SetRemoteAddr(*(QuicAddr*)ServerAddress))) return;
+    if (QUIC_FAILED(InitStatus = Start(Config, HostName, QuicAddrGetPort((QUIC_ADDR*)ServerAddress)))) return;
 }
 
 #ifdef MSH3_SERVER_SUPPORT

--- a/lib/msh3.hpp
+++ b/lib/msh3.hpp
@@ -308,7 +308,7 @@ struct MsH3Connection : public MsQuicConnection {
         const MSH3_CONNECTION_IF* Interface,
         void* IfContext,
         const char* ServerName,
-        uint16_t Port,
+        const MSH3_ADDR* ServerAddress,
         bool Unsecure
         );
 

--- a/msh3.h
+++ b/msh3.h
@@ -16,20 +16,16 @@
 #include <winsock2.h>
 #include <ws2def.h>
 #include <ws2ipdef.h>
+#define MSH3_CALL __cdecl
 #else
 #include <netinet/ip.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
+#define MSH3_CALL
 #endif
 
 #if defined(__cplusplus)
 extern "C" {
-#endif
-
-#ifdef _WIN32
-#define MSH3_CALL __cdecl
-#else
-#define MSH3_CALL
 #endif
 
 typedef struct MSH3_API MSH3_API;
@@ -88,6 +84,12 @@ typedef union MSH3_ADDR {
     struct sockaddr_in Ipv4;
     struct sockaddr_in6 Ipv6;
 } MSH3_ADDR;
+
+#if _WIN32
+#define MSH3_SET_PORT(addr, port) (addr)->Ipv4.sin_port = _byteswap_ushort(port)
+#else
+#define MSH3_SET_PORT(addr, port) (addr)->Ipv4.sin_port = __builtin_bswap16(port)
+#endif
 
 typedef struct MSH3_HEADER {
     const char* Name;
@@ -172,7 +174,7 @@ MsH3ConnectionOpen(
     const MSH3_CONNECTION_IF* Interface,
     void* IfContext,
     const char* ServerName,
-    uint16_t Port,
+    const MSH3_ADDR* ServerAddress,
     bool Unsecure
     );
 

--- a/test/msh3test.hpp
+++ b/test/msh3test.hpp
@@ -61,6 +61,14 @@ struct TestApi {
     operator MSH3_API* () const noexcept { return Handle; }
 };
 
+struct TestAddr {
+    MSH3_ADDR Addr {0};
+    TestAddr(uint16_t Port = 4433) {
+        MSH3_SET_PORT(&Addr, Port);
+    }
+    operator const MSH3_ADDR* () const noexcept { return &Addr; }
+};
+
 struct TestConnection {
     MSH3_CONNECTION* Handle { nullptr };
     TestWaitable<bool> Connected;
@@ -69,10 +77,10 @@ struct TestConnection {
     TestConnection(
         TestApi& Api,
         const char* ServerName = "localhost",
-        uint16_t Port = 4433,
+        const TestAddr& ServerAddress = TestAddr(),
         bool Unsecure = true
         ) noexcept : CleanUp(CleanUpManual) {
-        Handle = MsH3ConnectionOpen(Api, &Interface, this, ServerName, Port, Unsecure);
+        Handle = MsH3ConnectionOpen(Api, &Interface, this, ServerName, ServerAddress, Unsecure);
     }
     TestConnection(MSH3_CONNECTION* ServerHandle) noexcept : Handle(ServerHandle), CleanUp(CleanUpAutoDelete) {
         MsH3ConnectionSetCallbackInterface(Handle, &Interface, this);
@@ -208,18 +216,6 @@ struct TestCertificate {
     ~TestCertificate() noexcept { if (Handle) { MsH3CertificateClose(Handle); } }
     bool IsValid() const noexcept { return Handle != nullptr; }
     operator MSH3_CERTIFICATE* () const noexcept { return Handle; }
-};
-
-struct TestAddr {
-    MSH3_ADDR Addr {0};
-    TestAddr(uint16_t Port = 4433) {
-#if _WIN32
-        Addr.Ipv4.sin_port = _byteswap_ushort(Port);
-#else
-        Addr.Ipv4.sin_port = __builtin_bswap16(Port);
-#endif
-    }
-    operator const MSH3_ADDR* () const noexcept { return &Addr; }
 };
 
 struct TestListener {

--- a/tool/msh3_app.cpp
+++ b/tool/msh3_app.cpp
@@ -19,12 +19,12 @@ using namespace std;
 
 struct Arguments {
     const char* Host { nullptr };
-    uint16_t Port { 443 };
+    MSH3_ADDR Address { 0 };
     vector<const char*> Paths;
     bool Unsecure { false };
     bool Print { false };
     uint32_t Count { 1 };
-    Arguments() { }
+    Arguments() { MSH3_SET_PORT(&Address, 443); }
 } Args;
 
 std::mutex Mutex;
@@ -93,7 +93,7 @@ void ParseArgs(int argc, char **argv) {
     char *port = strrchr(argv[1], ':');
     if (port) {
         *port = 0; port++;
-        Args.Port = (uint16_t)atoi(port);
+        MSH3_SET_PORT(&Args.Address, (uint16_t)atoi(port));
     }
 
     // Parse options.
@@ -147,10 +147,10 @@ int MSH3_CALL main(int argc, char **argv) {
 
     auto Api = MsH3ApiOpen();
     if (Api) {
-        auto Connection = MsH3ConnectionOpen(Api, &ConnCallbacks, nullptr, Args.Host, Args.Port, Args.Unsecure);
+        auto Connection = MsH3ConnectionOpen(Api, &ConnCallbacks, nullptr, Args.Host, &Args.Address, Args.Unsecure);
         if (Connection) {
             for (auto Path : Args.Paths) {
-                printf("HTTP/3 GET https://%s:%d%s\n\n", Args.Host, Args.Port, Path);
+                printf("HTTP/3 GET https://%s%s\n", Args.Host, Path);
                 Headers[1].Value = Path;
                 Headers[1].ValueLength = strlen(Path);
                 for (uint32_t i = 0; i < Args.Count; ++i) {


### PR DESCRIPTION
Adds support for clients to specify the full server IP address. They can still use wildcard address, and just specify port if desired.