### PR TITLE
Improve libmsh3.pc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,14 @@
 
 cmake_minimum_required(VERSION 3.16)
 
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/lib/msh3.ver" msh3_ver)
+if(NOT msh3_ver MATCHES ".*#define VER_MAJOR ([0-9]+).*#define VER_MINOR ([0-9]+).*#define VER_PATCH ([0-9]+).*")
+    message(FATAL_ERROR "Cannot parse version from lib/msh3.ver")
+endif()
+set(msh3_ver "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}")
+
 message(STATUS "msh3: Configuration start...")
-project(msh3)
+project(msh3 VERSION "${msh3_ver}")
 
 option(MSH3_TOOL "Build tool" OFF)
 option(MSH3_TEST "Build tests" OFF)

--- a/lib/libmsh3.pc.in
+++ b/lib/libmsh3.pc.in
@@ -4,7 +4,7 @@
 prefix=@prefix@
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
-includedir=${exec_prefix}/include
+includedir=${prefix}/include
 
 Name: libmsh3
 Description: Minimal HTTP/3 client on top of MsQuic

--- a/lib/libmsh3.pc.in
+++ b/lib/libmsh3.pc.in
@@ -8,6 +8,6 @@ includedir=${prefix}/include
 
 Name: libmsh3
 Description: Minimal HTTP/3 client on top of MsQuic
-Version: 0.1.0
+Version: @PROJECT_VERSION@
 Libs: -L${libdir} -lmsh3
 Cflags: -I${includedir}


### PR DESCRIPTION
Include dirs are usually based on `${prefix}`. In vcpkg, this assumption is wired in automatic pc file fixup: release and debug configurations use different (exec_)prefix, but share one include dir.

In addition, automatically export the proper version. Injecting the version into the CMake `project` command makes it available in standard CMake variables.

For now, the version is parsed from `lib/msh3.def`. FTR you might maintain the version directly in `project` and generate `lib/msh3.def` instead.