### PR TITLE
CMake: Enable configuration of CMAKE_BUILD_TYPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ cmake_minimum_required(VERSION 3.16)
 message(STATUS "msh3: Configuration start...")
 project(msh3)
 
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type on single-configuration generators")
+
 option(MSH3_TOOL "Build tool" OFF)
 option(MSH3_TEST "Build tests" OFF)
 
@@ -76,7 +78,6 @@ else()
 endif()
 set(QUIC_BUILD_SHARED ON CACHE BOOL "Builds MsQuic as a dynamic library")
 set(QUIC_ENABLE_LOGGING ON CACHE BOOL "Enable MsQuic logging")
-set(CMAKE_BUILD_TYPE "Release")
 add_subdirectory(msquic)
 target_compile_features(msh3_headers INTERFACE cxx_std_20)
 


### PR DESCRIPTION
msh3 used to hardcode the value of `CMAKE_BUILD_TYPE` to `Release`, in the middle of `CMakeLists.txt`. This is unexpected and a source of problems.
 - In general, `CMAKE_BUILD_TYPE` is a variable which is meant to be controlled by the user. Also package managers like vcpkg make use of this as a general input variable.
 - Setting a normal variable to a hard coded variable in the middle of the build script will hide the user input from this point. But users may easily overlook the trigger for behavioral inconsistencies they observe for different parts of the build.
 - CMake encourages to use a different value than the default empty string.
The natural way to implement defaults for user controlled variables is using cache variables.

This PR aligns msh3 with common practice: It sets a default early in `CMakeLists.txt`, as a cache variable subject to user control.