### PR TITLE
CMake: Fix msh3-config.cmake configuration

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -29,7 +29,7 @@ install(TARGETS msh3 EXPORT msh3
     LIBRARY DESTINATION lib
 )
 install(FILES ../msh3.h DESTINATION include)
-configure_file(msh3-config.cmake.in ${CMAKE_BINARY_DIR}/msh3-config.cmake)
+configure_file(msh3-config.cmake.in ${CMAKE_BINARY_DIR}/msh3-config.cmake @ONLY)
 install(FILES ${CMAKE_BINARY_DIR}/msh3-config.cmake DESTINATION share/msh3)
 install(EXPORT msh3 DESTINATION share/msh3)
 set(prefix ${CMAKE_INSTALL_PREFIX})

--- a/lib/msh3-config.cmake.in
+++ b/lib/msh3-config.cmake.in
@@ -1,4 +1,4 @@
 include(CMakeFindDependencyMacro)
 @FILENAME_DEP_REPLACE@
 
-include(${SELF_DIR}/msh3.cmake)
+include("${CMAKE_CURRENT_LIST_DIR}/msh3.cmake")


### PR DESCRIPTION
- Chainloading the exported config has an expression based on `${SELF_DIR}`.
  - The actual value is not known at msh3 build time.
  - Due to lack of `@ONLY`, `configure_file` substitutes the expression with an empty string at msh3 build time. *This makes the exported config unusable.*
  - The desired values is available as `${CMAKE_CURRENT_LIST_DIR}` when the configuration is used.
  - Updating the expression and using `@ONLY` fixes chainloading and simplifies maintenance of `msh4-config.cmake.in` by separating build-time substitutions (`@VAR@`) from usage-time substitutions (`${VAR}`). This is *common practice* in generating CMake config files.

(The cmake config template still carries the `@FILENAME_DEP_REPLACE@` placeholder which is probably copied from msquic but not set in msh3.)