### PR TITLE
Fix invalid bit-field

### DIFF
--- a/msh3.h
+++ b/msh3.h
@@ -374,7 +374,11 @@ typedef struct MSH3_REQUEST_EVENT {
             bool AppCloseInProgress       : 1;
             bool ConnectionShutdownByApp  : 1;
             bool ConnectionClosedRemotely : 1;
-            bool RESERVED                 : 5;
+            bool RESERVED                 : 1;
+            bool RESERVED_2               : 1;
+            bool RESERVED_3               : 1;
+            bool RESERVED_4               : 1;
+            bool RESERVED_5               : 1;
             uint64_t ConnectionErrorCode;
             MSH3_STATUS ConnectionCloseStatus;
         } SHUTDOWN_COMPLETE;
@@ -487,7 +491,13 @@ typedef struct MSH3_LISTENER_EVENT {
     union {
         struct {
             bool AppCloseInProgress  : 1;
-            bool RESERVED            : 7;
+            bool RESERVED            : 1;
+            bool RESERVED_2          : 1;
+            bool RESERVED_3          : 1;
+            bool RESERVED_4          : 1;
+            bool RESERVED_5          : 1;
+            bool RESERVED_6          : 1;
+            bool RESERVED_7          : 1;
         } SHUTDOWN_COMPLETE;
         struct {
             MSH3_CONNECTION* Connection;


### PR DESCRIPTION
Fixes gcc compiler error when using msh3:
~~~
In file included from /vcpkg/scripts/test_ports/vcpkg-ci-msh3/project/main.c:1:
/vcpkg/installed/x64-linux/include/msh3.h:377:18: error: width of ‘RESERVED’ exceeds its type
  377 |             bool RESERVED                 : 5;
      |                  ^~~~~~~~
/vcpkg/installed/x64-linux/include/msh3.h:490:18: error: width of ‘RESERVED’ exceeds its type
  490 |             bool RESERVED            : 7;
      |                  ^~~~~~~~
~~~
According to https://en.cppreference.com/w/c/language/bit_field, the width is "an integer  constant expression with a value greater or equal to zero and less or equal the number of bits in the underlying type. So for a one-bit `bool` type, width cannot exceed 1.

Noticed in the vcpkg test port for msh3.