### PR TITLE
CMake: Trim explicit tool and test link libs

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,5 +3,5 @@
 
 set(SOURCES msh3test.cpp)
 add_executable(msh3test ${SOURCES})
-target_link_libraries(msh3test msh3 inc warnings msquic ls-qpack msh3_headers)
+target_link_libraries(msh3test msh3 msh3_headers)
 install(TARGETS msh3test EXPORT msh3 DESTINATION lib)

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -3,5 +3,5 @@
 
 set(SOURCES msh3_app.cpp)
 add_executable(msh3app ${SOURCES})
-target_link_libraries(msh3app msh3 inc warnings msquic ls-qpack msh3_headers)
+target_link_libraries(msh3app msh3 msh3_headers)
 install(TARGETS msh3app EXPORT msh3 DESTINATION lib)


### PR DESCRIPTION
Originally I just wanted to change `ls-qpack` to `ls-qpack::ls-qpack`, to amend #255.

But after looking at those sources, they only use the `msh3` interface, and so those executables should use only this link library.

