### PR TITLE
Relax C++ requirement for usage

### DIFF
--- a/msh3.hpp
+++ b/msh3.hpp
@@ -33,20 +33,20 @@ template<typename T>
 struct MsH3Waitable {
     T Get() const { return State; }
     void Set(T state) {
-        std::lock_guard Lock{Mutex};
+        std::lock_guard<std::mutex> Lock{Mutex};
         State = state;
         Event.notify_all();
     }
     T Wait() {
         if (!State) {
-            std::unique_lock Lock{Mutex};
+            std::unique_lock<std::mutex> Lock{Mutex};
             Event.wait(Lock, [&]{return State;});
         }
         return State;
     }
     bool WaitFor(uint32_t milliseconds TEST_DEF(250)) {
         if (!State) {
-            std::unique_lock Lock{Mutex};
+            std::unique_lock<std::mutex> Lock{Mutex};
             return Event.wait_for(Lock, milliseconds*1ms, [&]{return State;});
         }
         return true;


### PR DESCRIPTION
Just a suggestion split out from other work, tested for building tool+test with gcc 9.4:
The header can be used without explicitly requiring C++20 or C+17.

In fact the library could also be compiled with C++17 with this change, C++17 is a usage requirement currently exported by msquic, so there is no point in going lower.

If this change isn't accepted, the CMake config needs to be extended to export the C++20 usage requirement.
