### PR TITLE
Install tools and tests to 'bin'

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,4 +4,4 @@
 set(SOURCES msh3test.cpp)
 add_executable(msh3test ${SOURCES})
 target_link_libraries(msh3test msh3 msh3_headers)
-install(TARGETS msh3test EXPORT msh3 DESTINATION lib)
+install(TARGETS msh3test EXPORT msh3 RUNTIME DESTINATION bin)

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -4,4 +4,4 @@
 set(SOURCES msh3_app.cpp)
 add_executable(msh3app ${SOURCES})
 target_link_libraries(msh3app msh3 msh3_headers)
-install(TARGETS msh3app EXPORT msh3 DESTINATION lib)
+install(TARGETS msh3app EXPORT msh3 RUNTIME DESTINATION bin)


### PR DESCRIPTION
Similar to the RUNTIME component of libraries, executables are RUNTIME and shall go to ~lib~bin.

Alternatives:
- Packages usually don't install tests. The installation command could be removed.
- Install destinations could be made configurable in a standard way with CMake package `GNUInstallDirs` and the variables it provides. 
  (I see that this is partially implemented in msquic.)