### PR TITLE
Dissolve msh3_headers, cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,20 +39,16 @@ if (WIN32)
     # Statically link the OS included part of the runtime.
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
     set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib")
-    set(QUIC_COMMON_DEFINES WIN32_LEAN_AND_MEAN SECURITY_WIN32)
-    # TODO - Get these to work on Linux
-    list(APPEND MSH3_COMMON_DEFINES VER_BUILD_ID=${MSH3_VER_BUILD_ID})
-    list(APPEND MSH3_COMMON_DEFINES VER_SUFFIX=${MSH3_VER_SUFFIX})
+
+    add_compile_definitions(WIN32_LEAN_AND_MEAN)
     if(HAS_SPECTRE)
-        list(APPEND QUIC_COMMON_FLAGS /Qspectre)
+        add_compile_options(/Qspectre)
     endif()
     # Compile/link flags
     set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /GL /Zi")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /GL /Zi")
     set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /LTCG /IGNORE:4075 /DEBUG /OPT:REF /OPT:ICF")
     set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /LTCG /IGNORE:4075 /DEBUG /OPT:REF /OPT:ICF")
-else()
-    set(QUIC_COMMON_DEFINES _GNU_SOURCE)
 endif()
 
 set(MSH3_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/bin CACHE STRING "Output directory for build artifacts")
@@ -64,12 +60,6 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE ${MSH3_OUTPUT_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${MSH3_OUTPUT_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG ${MSH3_OUTPUT_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${MSH3_OUTPUT_DIR})
-
-# Public include header.
-add_library(msh3_headers INTERFACE)
-target_compile_features(msh3_headers INTERFACE cxx_std_20)
-target_compile_definitions(msh3_headers INTERFACE ${MSH3_COMMON_DEFINES})
-target_include_directories(msh3_headers INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 
 # ls-qpack dependency
 option(MSH3_USE_EXTERNAL_LSQPACK "Use an external ls-qpack installation")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -7,8 +7,16 @@ else()
     set(SOURCES msh3.cpp)
 endif()
 add_library(msh3 SHARED ${SOURCES})
-target_include_directories(msh3 PUBLIC $<INSTALL_INTERFACE:include>)
-target_link_libraries(msh3 PRIVATE msquic msquic_platform ls-qpack::ls-qpack msh3_headers)
+target_compile_features(msh3 PRIVATE cxx_std_20)
+target_compile_definitions(msh3 PRIVATE
+    "VER_BUILD_ID=${MSH3_VER_BUILD_ID}"
+    "VER_SUFFIX=${MSH3_VER_SUFFIX}"
+)
+target_include_directories(msh3 PUBLIC
+    $<BUILD_INTERFACE:${msh3_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(msh3 PRIVATE msquic msquic_platform ls-qpack::ls-qpack)
 if (NOT BUILD_SHARED_LIBS)
     target_link_libraries(msh3 PRIVATE base_link)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,5 +3,5 @@
 
 set(SOURCES msh3test.cpp)
 add_executable(msh3test ${SOURCES})
-target_link_libraries(msh3test msh3 msh3_headers)
+target_link_libraries(msh3test msh3)
 install(TARGETS msh3test EXPORT msh3 RUNTIME DESTINATION bin)

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -3,5 +3,5 @@
 
 set(SOURCES msh3_app.cpp)
 add_executable(msh3app ${SOURCES})
-target_link_libraries(msh3app msh3 msh3_headers)
+target_link_libraries(msh3app msh3)
 install(TARGETS msh3app EXPORT msh3 RUNTIME DESTINATION bin)

--- a/tool/msh3_app.cpp
+++ b/tool/msh3_app.cpp
@@ -6,9 +6,12 @@
 --*/
 
 #include "msh3.hpp"
-#include <vector>
-#include <cstring>
+
 #include <atomic>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
 
 using namespace std;
 


### PR DESCRIPTION
This is probably the most intrusive PR in today's series.

- Revise `QUIC_...` variables and either remove or migrate to `MSH3`.
  - The vendored msquic build overrides the variables.
  - Let `/Qspectre` potentially take effect. (Note that `HAS_SPECTRE` is not wired to a visible option or active check in msh3. Maybe it should be removed entirely. The user can pass this with toolchain or variables.)
  - Drop `_GNU_SOURCE`. (It was not needed in the past.)
- Remove the `msh3_header` interface target:
  - The actual include dir is a public property of `msh3` (subject to INSTALL_INTERFACE/BUILD_INTERFACE).
  - ~C++17 is enough to build the lib now.~
    Building the lib needs at least C++20 for "use of designated initializers" (MSVC).
    (Not exported as a transitive usage requirement.)
  - `WIN32_LEAN_AND_MEAN` is a project-wide definition. (Not exported as a transitive usage requirement.)
  - `VER_BUILD_ID` and `VER_SUFFIX` are used only by `msh3`. (Not exported as a transitive usage requirement.) I didn't notice problems on non-windows.
- Add additional includes to msh3_app. Not sure why the Ubuntu build didn't complain before, but it did now.

Linking `msh3app` and `mhs3test` now looks as trivial as it should, with proper use of CMake.