### PR TITLE
Refactor to #ifdef _WIN32

### DIFF
--- a/lib/msh3_internal.hpp
+++ b/lib/msh3_internal.hpp
@@ -35,7 +35,7 @@
 #define MSH3_VERSION_ONLY 1
 #include "msh3.ver"
 
-#if _WIN32
+#ifdef _WIN32
 #define CxPlatByteSwapUint16 _byteswap_ushort
 #define CxPlatByteSwapUint32 _byteswap_ulong
 #define CxPlatByteSwapUint64 _byteswap_uint64

--- a/msh3.h
+++ b/msh3.h
@@ -198,7 +198,7 @@ typedef union MSH3_ADDR {
     struct sockaddr_in6 Ipv6;
 } MSH3_ADDR;
 
-#if _WIN32
+#ifdef _WIN32
 #define MSH3_SET_PORT(addr, port) (addr)->Ipv4.sin_port = _byteswap_ushort(port)
 #else
 #define MSH3_SET_PORT(addr, port) (addr)->Ipv4.sin_port = __builtin_bswap16(port)


### PR DESCRIPTION
Refactor to #ifdef _WIN32

It create a warning: 
```
/home/runner/msh3/include/msh3.h:201:5: warning: "_WIN32" is not defined, evaluates to 0 [-Wundef]
  201 | #if _WIN32
```
